### PR TITLE
Dev

### DIFF
--- a/data/eval/golden.json
+++ b/data/eval/golden.json
@@ -1,7 +1,7 @@
 {
   "ENC-001": {
     "expected_stages": ["CODING_CHARGE_CAPTURE", "CLAIMS_SUBMISSION"],
-    "expected_final_status": "CLAIM_SUBMITTED",
+    "expected_final_status": "CLAIM_ACCEPTED",
     "needs_prior_auth": false,
     "description": "Routine office visit (Aetna, eligible)"
   },
@@ -12,10 +12,42 @@
     "expected_auth_outcome": "approved",
     "description": "MRI knee with prior auth (UnitedHealthcare)"
   },
+  "ENC-003": {
+    "expected_stages": ["HUMAN_ESCALATION"],
+    "expected_final_status": "NEEDS_REVIEW",
+    "needs_prior_auth": false,
+    "expected_escalation": true,
+    "description": "Inpatient surgery (high charges) - triggers escalation"
+  },
   "ENC-004": {
     "expected_stages": ["DENIAL_APPEAL"],
     "expected_final_status": null,
     "needs_prior_auth": false,
     "description": "Denial scenario (Cigna) - appeal workflow"
+  },
+  "ENC-005": {
+    "expected_stages": ["ELIGIBILITY_VERIFICATION"],
+    "expected_final_status": "NOT_ELIGIBLE",
+    "needs_prior_auth": false,
+    "description": "Eligibility mismatch - member terminated (Anthem)"
+  },
+  "ENC-006": {
+    "expected_stages": ["DENIAL_APPEAL"],
+    "expected_final_status": null,
+    "needs_prior_auth": false,
+    "description": "Denial CO-4 only - appeal workflow (UnitedHealthcare)"
+  },
+  "ENC-007": {
+    "expected_stages": ["DENIAL_APPEAL"],
+    "expected_final_status": "CLAIM_DENIED",
+    "needs_prior_auth": false,
+    "description": "Duplicate claim (CO-18) - appeal not viable"
+  },
+  "ENC-008": {
+    "expected_stages": ["PRIOR_AUTHORIZATION"],
+    "expected_final_status": "AUTH_DENIED",
+    "needs_prior_auth": true,
+    "expected_auth_outcome": "denied",
+    "description": "Prior auth denied - requires RCM_PRIOR_AUTH_MOCK_DENY_PAYER=AuthDenyPayer"
   }
 }

--- a/data/eval/golden.json
+++ b/data/eval/golden.json
@@ -1,50 +1,69 @@
 {
   "ENC-001": {
-    "expected_stages": ["CODING_CHARGE_CAPTURE", "CLAIMS_SUBMISSION"],
+    "expected_stages": [
+      "CODING_CHARGE_CAPTURE",
+      "CLAIMS_SUBMISSION"
+    ],
     "expected_final_status": "CLAIM_ACCEPTED",
     "needs_prior_auth": false,
     "description": "Routine office visit (Aetna, eligible)"
   },
   "ENC-002": {
-    "expected_stages": ["PRIOR_AUTHORIZATION", "CODING_CHARGE_CAPTURE", "CLAIMS_SUBMISSION"],
+    "expected_stages": [
+      "PRIOR_AUTHORIZATION",
+      "CODING_CHARGE_CAPTURE",
+      "CLAIMS_SUBMISSION"
+    ],
     "expected_final_status": "CLAIM_SUBMITTED",
     "needs_prior_auth": true,
     "expected_auth_outcome": "approved",
     "description": "MRI knee with prior auth (UnitedHealthcare)"
   },
   "ENC-003": {
-    "expected_stages": ["HUMAN_ESCALATION"],
+    "expected_stages": [
+      "HUMAN_ESCALATION"
+    ],
     "expected_final_status": "NEEDS_REVIEW",
     "needs_prior_auth": false,
     "expected_escalation": true,
     "description": "Inpatient surgery (high charges) - triggers escalation"
   },
   "ENC-004": {
-    "expected_stages": ["DENIAL_APPEAL"],
+    "expected_stages": [
+      "DENIAL_APPEAL"
+    ],
     "expected_final_status": null,
     "needs_prior_auth": false,
     "description": "Denial scenario (Cigna) - appeal workflow"
   },
   "ENC-005": {
-    "expected_stages": ["ELIGIBILITY_VERIFICATION"],
+    "expected_stages": [
+      "ELIGIBILITY_VERIFICATION"
+    ],
     "expected_final_status": "NOT_ELIGIBLE",
     "needs_prior_auth": false,
     "description": "Eligibility mismatch - member terminated (Anthem)"
   },
   "ENC-006": {
-    "expected_stages": ["DENIAL_APPEAL"],
+    "expected_stages": [
+      "DENIAL_APPEAL"
+    ],
     "expected_final_status": null,
     "needs_prior_auth": false,
     "description": "Denial CO-4 only - appeal workflow (UnitedHealthcare)"
   },
   "ENC-007": {
-    "expected_stages": ["DENIAL_APPEAL"],
+    "expected_stages": [
+      "DENIAL_APPEAL"
+    ],
     "expected_final_status": "CLAIM_DENIED",
     "needs_prior_auth": false,
     "description": "Duplicate claim (CO-18) - appeal not viable"
   },
   "ENC-008": {
-    "expected_stages": ["PRIOR_AUTHORIZATION"],
+    "expected_stages": [
+      "PRIOR_AUTHORIZATION"
+    ],
     "expected_final_status": "AUTH_DENIED",
     "needs_prior_auth": true,
     "expected_auth_outcome": "denied",

--- a/data/examples/encounter_007_duplicate_claim.json
+++ b/data/examples/encounter_007_duplicate_claim.json
@@ -1,0 +1,16 @@
+{
+  "encounter_id": "ENC-007",
+  "patient": {"age": 40, "gender": "M", "zip": "10001"},
+  "insurance": {"payer": "Aetna", "member_id": "AET123456789", "plan_type": "PPO"},
+  "date": "2026-02-15",
+  "type": "outpatient_procedure",
+  "procedures": [{"code": "99213", "description": "Office visit, established patient, low complexity"}],
+  "diagnoses": [{"code": "J06.9", "description": "Acute upper respiratory infection, unspecified"}],
+  "clinical_notes": "Duplicate claim - same service already paid. CO-18. Resubmission not appropriate.",
+  "documents": ["denial_letter.pdf"],
+  "denial_info": {
+    "claim_id": "CLM-007",
+    "reason_codes": ["CO-18"],
+    "denial_date": "2026-02-10"
+  }
+}

--- a/data/examples/encounter_008_auth_denied.json
+++ b/data/examples/encounter_008_auth_denied.json
@@ -1,0 +1,11 @@
+{
+  "encounter_id": "ENC-008",
+  "patient": {"age": 55, "gender": "M", "zip": "10001"},
+  "insurance": {"payer": "AuthDenyPayer", "member_id": "AUTH-DENY-001", "plan_type": "PPO"},
+  "date": "2026-02-16",
+  "type": "outpatient_procedure",
+  "procedures": [{"code": "73721", "description": "MRI knee without contrast"}],
+  "diagnoses": [{"code": "M25.561", "description": "Pain in right knee"}],
+  "clinical_notes": "Knee pain, MRI ordered. Prior auth required. Use RCM_PRIOR_AUTH_MOCK_DENY_PAYER=AuthDenyPayer for eval.",
+  "documents": ["clinic_note.txt"]
+}

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -51,7 +51,7 @@ Pipeline mode (`--pipeline`):
 
 - `multi` (default): Multi-stage pipeline (`process_encounter_multi_stage`)
 - `single`: Single-stage pipeline (`process_encounter`, one route → one crew)
-- `both`: Runs both; writes `e2e_eval_single.json` and `e2e_eval_multi.json` to output dir
+- `both`: Runs both; writes `e2e_eval_single.json` and `e2e_eval_multi.json` to the output directory. With `eval-all`, that directory is `--output-dir` (default `reports`). With `eval-e2e`, it is the parent of `--output` when a file path is given (e.g. `-o reports/out.json` → `reports/`); if only a filename is given (e.g. `-o out.json`), reports are written to the current working directory.
 
 ### Full suite (router + e2e)
 

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -47,13 +47,19 @@ rcm-agent eval-e2e -o reports/e2e_eval.json
 
 Requires `OPENAI_API_KEY` in `.env`.
 
+Pipeline mode (`--pipeline`):
+
+- `multi` (default): Multi-stage pipeline (`process_encounter_multi_stage`)
+- `single`: Single-stage pipeline (`process_encounter`, one route → one crew)
+- `both`: Runs both; writes `e2e_eval_single.json` and `e2e_eval_multi.json` to output dir
+
 ### Full suite (router + e2e)
 
 ```bash
 rcm-agent eval-all -o reports
 ```
 
-Writes `reports/router_eval.json` and `reports/e2e_eval.json` (plus `e2e_eval.md` summary). Use `--golden <path>` to override the default golden file (repo `data/eval/golden.json`) for e2e comparison.
+Writes `reports/router_eval.json` and `reports/e2e_eval.json` (plus `e2e_eval.md` summary). Use `--golden <path>` to override the default golden file (repo `data/eval/golden.json`) for e2e comparison. Use `--pipeline single|multi|both` for e2e pipeline mode.
 
 ### Pytest
 
@@ -72,9 +78,11 @@ Writes `reports/router_eval.json` and `reports/e2e_eval.json` (plus `e2e_eval.md
 
 ### E2E report (`e2e_eval.json`)
 
-- `total`, `pipeline_successes`, `pipeline_success_rate`
+- `total`, `pipeline_successes`, `pipeline_success_rate`, `pipeline_mode`
 - `escalations`, `prior_auth_*`, `claim_readiness_rate`, `router_alignment_rate`
 - `records`: per-encounter stages run, final status, success, artifacts
+
+When `--pipeline both`, reports are written as `e2e_eval_single.json` and `e2e_eval_multi.json`.
 
 ### E2E markdown summary (`e2e_eval.md`)
 
@@ -92,7 +100,7 @@ Optional expected outcomes for regression testing. Edit `data/eval/golden.json`:
 {
   "ENC-001": {
     "expected_stages": ["CODING_CHARGE_CAPTURE", "CLAIMS_SUBMISSION"],
-    "expected_final_status": "CLAIM_SUBMITTED",
+    "expected_final_status": "CLAIM_ACCEPTED",
     "needs_prior_auth": false
   }
 }
@@ -104,33 +112,46 @@ When golden data exists, e2e eval computes:
 - **Final status alignment rate:** when `expected_final_status` is set (non-null), fraction where actual final status matches
 - **Needs prior auth alignment rate:** when `needs_prior_auth` is set, fraction where encounter’s prior-auth need matches the golden value
 
+Golden keys: `expected_stages`, `expected_final_status`, `expected_escalation`, `expected_auth_outcome`, `needs_prior_auth`, `description`.
+
 ## Coverage and limitations
 
-The eval suite is **not** comprehensive to the entire RCM agentic system. It covers a subset of behaviors and scenarios.
+The eval suite covers the RCM agentic system within practical scope. Some behaviors remain out of scope.
 
 **What is covered**
 
 - **Router:** Heuristic vs LLM agreement (primary stage and multi-stage sequence) on all example encounters.
-- **E2E pipeline:** Multi-stage pipeline only (`process_encounter_multi_stage`) on the same 6 synthetic encounters. Metrics: success rate, router alignment (vs golden), prior-auth coverage, claim readiness, escalation count.
-- **Stages exercised in examples:** Eligibility (005), prior auth (002), coding + claims (001, 002), denial/appeal (004, 006), escalation (003 via high charges).
-- **Golden expectations:** Only ENC-001, ENC-002, ENC-004 have golden entries; ENC-003, ENC-005, ENC-006 have no expected_stages/expected_final_status.
+- **E2E pipeline:** Multi-stage (`process_encounter_multi_stage`) and single-stage (`process_encounter`) via `--pipeline single|multi|both`. Metrics: success rate, router alignment (vs golden), prior-auth coverage, claim readiness, escalation count.
+- **Stages exercised:** Eligibility (005), prior auth (002, 008), coding + claims (001, 002), denial/appeal (004, 006, 007), escalation (003 via high charges).
+- **Golden expectations:** All encounters (ENC-001 through ENC-008) have golden entries with `expected_stages`, `expected_final_status` (or null), `needs_prior_auth`, and optional `expected_escalation`.
+- **Failure scenarios:** ENC-007 (CO-18 duplicate → CLAIM_DENIED), ENC-008 (prior auth denied → AUTH_DENIED). Eval sets `RCM_PRIOR_AUTH_MOCK_DENY_PAYER=AuthDenyPayer` by default so ENC-008 produces AUTH_DENIED.
+- **Escalation:** ENC-003 has `expected_escalation: true`; success = pipeline correctly escalated.
+- **Persistence/CLI:** `test_persistence_cli_pipeline` (pytest `-m e2e`) runs `rcm-agent process` and asserts stored state matches pipeline output via `EncounterRepository`.
+- **Optional RAG:** Eval can run with `RCM_RAG_BACKEND=rag` (and Chroma index); report does not yet include RAG-quality metrics.
+- **Optional HTTP backends:** Run `rcm-agent serve-mock` in one terminal, then `ELIGIBILITY_BACKEND=http PRIOR_AUTH_BACKEND=http rcm-agent eval-e2e` to exercise HTTP; documented as optional.
 
 **What is not covered**
 
-- **Single-stage pipeline:** `process_encounter` (single-stage route → crew) is never run in eval; only multi-stage is evaluated.
-- **INTAKE / HUMAN_ESCALATION as router outputs:** Router can return INTAKE or HUMAN_ESCALATION; no examples or metrics target those paths explicitly (escalation is only measured when the pipeline returns HUMAN_ESCALATION due to escalation check, not router).
-- **RAG quality:** Eval uses default backends (typically mock). No assessment of RAG-backed coding guidelines or payer policy retrieval.
-- **Integrations:** All backends are mock (eligibility, prior auth, claims). No evaluation of HTTP or real payer behavior.
-- **Persistence:** No checks that DB state or audit trail are correct after a run.
+- **INTAKE / HUMAN_ESCALATION as router outputs:** Router can return INTAKE or HUMAN_ESCALATION; escalation is measured when pipeline returns HUMAN_ESCALATION due to `check_escalation()`, not router output.
+- **RAG quality:** No retrieval precision/recall or guideline coverage metrics.
+- **Production payer integrations:** No eval against real payer APIs.
 - **Crew output quality:** No metrics on coding accuracy, appeal packet quality, or eligibility output correctness—only pipeline success and router alignment.
-- **Failure scenarios:** No encounter with expected AUTH_DENIED or CLAIM_DENIED; no golden expectations for remittance denial or appeal failure.
-- **CLI and other entrypoints:** Eval does not run via `rcm-agent process` (CLI + persistence); it calls the pipeline directly.
-
-To make the eval more comprehensive, consider: adding golden entries for all encounters (003, 005, 006); adding scenarios for AUTH_DENIED and CLAIM_DENIED; evaluating single-stage pipeline; optionally evaluating with RAG and HTTP backends; and adding crew-level or outcome-quality metrics.
 
 ## Interpreting Metrics
 
-- **Pipeline success rate:** High is good. Low may indicate escalation thresholds, mock backend behavior, or LLM variability.
+- **Pipeline success rate:** High is good. For failure scenarios (ENC-007, ENC-008), success = pipeline correctly produced the expected failure status.
 - **Router alignment:** High means pipeline stages match expectations; low may require routing rule or prompt tuning.
 - **Prior auth coverage:** Should be 1.0 for encounters with auth-required CPT codes (e.g. 73721, 70450).
 - **Claim readiness:** Fraction that reached claims submission; depends on prior stages completing successfully.
+- **Escalation alignment:** When golden has `expected_escalation: true`, success = pipeline correctly escalated (e.g. ENC-003).
+
+## Optional: RAG and HTTP backends
+
+**RAG:** Set `RCM_RAG_BACKEND=rag` and ensure Chroma index is available. Eval will use RAG for coding/prior-auth; report records whether RAG was used but does not include retrieval quality metrics.
+
+**HTTP backends:** To exercise the pipeline over HTTP:
+
+1. Start mock server: `rcm-agent serve-mock` (default port 8000)
+2. Run eval: `ELIGIBILITY_BACKEND=http PRIOR_AUTH_BACKEND=http CLAIMS_BACKEND=http rcm-agent eval-e2e -o reports/e2e_eval_http.json`
+
+This is optional and not part of default CI.

--- a/src/rcm_agent/crews/e2e_eval.py
+++ b/src/rcm_agent/crews/e2e_eval.py
@@ -134,8 +134,6 @@ class E2ESummary:
             else 0.0
         )
 
-    pipeline_mode: str = "multi"
-
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
             "total": self.total,

--- a/src/rcm_agent/crews/e2e_eval.py
+++ b/src/rcm_agent/crews/e2e_eval.py
@@ -21,6 +21,8 @@ from rcm_agent.models import Encounter, EncounterOutput, EncounterStatus, RcmSta
 
 logger = logging.getLogger(__name__)
 
+PIPELINE_MODES = ("single", "multi", "both")
+
 # Failure statuses that halt the pipeline
 _FAILURE_STATUSES = frozenset(
     {
@@ -57,6 +59,7 @@ class E2ERecord:
     router_aligned: bool | None
     final_status_aligned: bool | None = None
     needs_prior_auth_aligned: bool | None = None
+    auth_outcome_aligned: bool | None = None
     success: bool = False
     error: str | None = None
     artifacts: dict[str, Any] = field(default_factory=dict)
@@ -74,6 +77,7 @@ class E2ERecord:
             "router_aligned": self.router_aligned,
             "final_status_aligned": self.final_status_aligned,
             "needs_prior_auth_aligned": self.needs_prior_auth_aligned,
+            "auth_outcome_aligned": self.auth_outcome_aligned,
             "success": self.success,
             "error": self.error,
             "artifacts": self.artifacts,
@@ -97,6 +101,8 @@ class E2ESummary:
     golden_final_status_count: int = 0
     needs_prior_auth_aligned_count: int = 0
     golden_needs_prior_auth_count: int = 0
+    auth_outcome_aligned_count: int = 0
+    golden_auth_outcome_count: int = 0
     records: list[E2ERecord] = field(default_factory=list)
     pipeline_mode: str = "multi"
 
@@ -134,6 +140,14 @@ class E2ESummary:
             else 0.0
         )
 
+    @property
+    def auth_outcome_alignment_rate(self) -> float:
+        return (
+            self.auth_outcome_aligned_count / self.golden_auth_outcome_count
+            if self.golden_auth_outcome_count > 0
+            else 0.0
+        )
+
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
             "total": self.total,
@@ -155,6 +169,9 @@ class E2ESummary:
             "needs_prior_auth_aligned": self.needs_prior_auth_aligned_count,
             "golden_needs_prior_auth": self.golden_needs_prior_auth_count,
             "needs_prior_auth_alignment_rate": round(self.needs_prior_auth_alignment_rate, 3),
+            "auth_outcome_aligned": self.auth_outcome_aligned_count,
+            "golden_auth_outcome": self.golden_auth_outcome_count,
+            "auth_outcome_alignment_rate": round(self.auth_outcome_alignment_rate, 3),
             "records": [r.to_dict() for r in self.records],
         }
         d["pipeline_mode"] = self.pipeline_mode
@@ -220,7 +237,8 @@ def run_e2e_evaluation(
     output_path: str | Path | None = None,
     output_dir: str | Path | None = None,
     pipeline_mode: str = "multi",
-) -> E2ESummary:
+    prior_auth_deny_payer: str | None = None,
+) -> E2ESummary | tuple[E2ESummary, E2ESummary]:
     """
     Run e2e evaluation: full pipeline on each encounter, collect outcomes, compute metrics.
 
@@ -232,71 +250,87 @@ def run_e2e_evaluation(
         output_dir: If set, write report to output_dir/e2e_eval.json.
         pipeline_mode: "single" | "multi" | "both". single=process_encounter (one stage);
             multi=process_encounter_multi_stage (default); both=runs both, writes separate reports.
+        prior_auth_deny_payer: If set, use this payer name for mock AUTH_DENIED for the run only
+            (overrides env). If unset and env RCM_PRIOR_AUTH_MOCK_DENY_PAYER is empty, sets
+            "AuthDenyPayer" for the run and restores env afterward.
 
     Returns:
-        E2ESummary with per-encounter records and aggregate metrics.
+        E2ESummary for single/multi mode; (single_summary, multi_summary) for both mode.
     """
     # Ensure config is loaded (load_dotenv via settings)
     from rcm_agent.config import settings  # noqa: F401
 
-    # Enable AUTH_DENIED for ENC-008 when running full eval (AuthDenyPayer)
-    if os.environ.get("RCM_PRIOR_AUTH_MOCK_DENY_PAYER", "").strip() == "":
-        os.environ.setdefault("RCM_PRIOR_AUTH_MOCK_DENY_PAYER", "AuthDenyPayer")
+    _deny_key = "RCM_PRIOR_AUTH_MOCK_DENY_PAYER"
+    _had_deny_payer = _deny_key in os.environ
+    _saved_deny_value: str | None = os.environ.get(_deny_key) if _had_deny_payer else None
+    try:
+        if prior_auth_deny_payer is not None:
+            os.environ[_deny_key] = prior_auth_deny_payer
+        elif os.environ.get(_deny_key, "").strip() == "":
+            os.environ.setdefault(_deny_key, "AuthDenyPayer")
 
-    if encounters is None:
-        if examples_dir is None:
-            examples_dir = _default_examples_dir()
-        examples_dir = Path(examples_dir)
-        logger.info("Loading encounters from %s", examples_dir)
-        encounters = load_encounters_from_dir(examples_dir)
+        if encounters is None:
+            if examples_dir is None:
+                examples_dir = _default_examples_dir()
+            examples_dir = Path(examples_dir)
+            logger.info("Loading encounters from %s", examples_dir)
+            encounters = load_encounters_from_dir(examples_dir)
 
-    if not encounters:
-        logger.warning("No encounters to evaluate")
-        return E2ESummary()
+        if not encounters:
+            logger.warning("No encounters to evaluate")
+            return E2ESummary()
 
-    golden = _load_golden(Path(golden_path) if golden_path else _default_golden_path())
+        golden = _load_golden(Path(golden_path) if golden_path else _default_golden_path())
 
-    mode = (pipeline_mode or "multi").strip().lower()
-    if mode not in ("single", "multi", "both"):
-        mode = "multi"
+        mode = (pipeline_mode or "multi").strip().lower()
+        if mode not in PIPELINE_MODES:
+            mode = "multi"
 
-    def _run_single(enc: Encounter) -> list[EncounterOutput]:
-        out = process_encounter(enc)
-        return [out]
+        def _run_single(enc: Encounter) -> list[EncounterOutput]:
+            out = process_encounter(enc)
+            return [out]
 
-    def _run_multi(enc: Encounter) -> list[EncounterOutput]:
-        return process_encounter_multi_stage(enc)
+        def _run_multi(enc: Encounter) -> list[EncounterOutput]:
+            return process_encounter_multi_stage(enc)
 
-    run_pipeline = _run_single if mode == "single" else _run_multi
+        run_pipeline = _run_single if mode == "single" else _run_multi
 
-    if mode == "both":
-        summaries: list[tuple[str, E2ESummary]] = [
-            ("single", _run_e2e_pass(encounters, golden, _run_single, "single")),
-            ("multi", _run_e2e_pass(encounters, golden, _run_multi, "multi")),
-        ]
-        base = Path(output_dir) if output_dir else (Path(output_path).parent if output_path else Path("reports"))
-        base.mkdir(parents=True, exist_ok=True)
-        for name, s in summaries:
-            p = base / f"e2e_eval_{name}.json"
-            with open(p, "w", encoding="utf-8") as f:
-                json.dump(s.to_dict(), f, indent=2)
-            _write_markdown_summary(s, p.with_suffix(".md"))
-            logger.info("E2E eval %s report written to %s", name, p)
-        return summaries[-1][1]
+        if mode == "both":
+            summaries: list[tuple[str, E2ESummary]] = [
+                ("single", _run_e2e_pass(encounters, golden, _run_single, "single")),
+                ("multi", _run_e2e_pass(encounters, golden, _run_multi, "multi")),
+            ]
+            base = Path(output_dir) if output_dir else (Path(output_path).parent if output_path else Path("reports"))
+            base.mkdir(parents=True, exist_ok=True)
+            for name, s in summaries:
+                p = base / f"e2e_eval_{name}.json"
+                with open(p, "w", encoding="utf-8") as f:
+                    json.dump(s.to_dict(), f, indent=2)
+                _write_markdown_summary(s, p.with_suffix(".md"))
+                logger.info("E2E eval %s report written to %s", name, p)
+            return (summaries[0][1], summaries[1][1])
 
-    summary = _run_e2e_pass(encounters, golden, run_pipeline, mode)
-    summary.pipeline_mode = mode
+        summary = _run_e2e_pass(encounters, golden, run_pipeline, mode)
+        summary.pipeline_mode = mode
 
-    out = output_path or (Path(output_dir) / "e2e_eval.json" if output_dir else None)
-    if out:
-        out = Path(out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        with open(out, "w", encoding="utf-8") as f:
-            json.dump(summary.to_dict(), f, indent=2)
-        logger.info("E2E eval report written to %s", out)
-        _write_markdown_summary(summary, out.with_suffix(".md"))
+        out = output_path or (Path(output_dir) / "e2e_eval.json" if output_dir else None)
+        if out:
+            out = Path(out)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            with open(out, "w", encoding="utf-8") as f:
+                json.dump(summary.to_dict(), f, indent=2)
+            logger.info("E2E eval report written to %s", out)
+            _write_markdown_summary(summary, out.with_suffix(".md"))
 
-    return summary
+        return summary
+    finally:
+        if prior_auth_deny_payer is not None:
+            if _saved_deny_value is not None:
+                os.environ[_deny_key] = _saved_deny_value
+            else:
+                os.environ.pop(_deny_key, None)
+        elif not _had_deny_payer:
+            os.environ.pop(_deny_key, None)
 
 
 def _run_e2e_pass(
@@ -328,6 +362,7 @@ def _run_e2e_pass(
                     router_aligned=None,
                     final_status_aligned=None,
                     needs_prior_auth_aligned=None,
+                    auth_outcome_aligned=None,
                     success=False,
                     error=str(e),
                 )
@@ -374,6 +409,14 @@ def _run_e2e_pass(
         if "needs_prior_auth" in g:
             needs_prior_auth_aligned = prior_auth_needed == g["needs_prior_auth"]
 
+        auth_outcome_aligned: bool | None = None
+        if "expected_auth_outcome" in g and prior_auth_produced:
+            expected = (g.get("expected_auth_outcome") or "").strip().lower()
+            if expected == "approved":
+                auth_outcome_aligned = prior_auth_approved is True
+            elif expected == "denied":
+                auth_outcome_aligned = prior_auth_approved is False
+
         artifacts: dict[str, Any] = {}
         for o in outputs:
             if o.stage == RcmStage.PRIOR_AUTHORIZATION:
@@ -397,6 +440,7 @@ def _run_e2e_pass(
             router_aligned=router_aligned,
             final_status_aligned=final_status_aligned,
             needs_prior_auth_aligned=needs_prior_auth_aligned,
+            auth_outcome_aligned=auth_outcome_aligned,
             success=is_success,
             artifacts=artifacts,
         )
@@ -426,6 +470,10 @@ def _run_e2e_pass(
             summary.golden_needs_prior_auth_count += 1
             if needs_prior_auth_aligned:
                 summary.needs_prior_auth_aligned_count += 1
+        if auth_outcome_aligned is not None:
+            summary.golden_auth_outcome_count += 1
+            if auth_outcome_aligned:
+                summary.auth_outcome_aligned_count += 1
 
     return summary
 
@@ -435,6 +483,7 @@ def _write_markdown_summary(summary: E2ESummary, path: Path) -> None:
     lines = [
         "# E2E Evaluation Summary",
         "",
+        f"- **Pipeline mode:** {summary.pipeline_mode}",
         f"- **Total encounters:** {summary.total}",
         f"- **Pipeline success rate:** {summary.pipeline_success_rate:.1%}",
         f"- **Escalations:** {summary.escalations}",
@@ -452,6 +501,10 @@ def _write_markdown_summary(summary: E2ESummary, path: Path) -> None:
     if summary.golden_needs_prior_auth_count > 0:
         lines.append(
             f"- **Needs prior auth alignment (vs golden):** {summary.needs_prior_auth_aligned_count}/{summary.golden_needs_prior_auth_count}"
+        )
+    if summary.golden_auth_outcome_count > 0:
+        lines.append(
+            f"- **Auth outcome alignment (vs golden):** {summary.auth_outcome_aligned_count}/{summary.golden_auth_outcome_count}"
         )
     lines.extend(
         [

--- a/src/rcm_agent/crews/e2e_eval.py
+++ b/src/rcm_agent/crews/e2e_eval.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 from rcm_agent.crews.main_crew import process_encounter, process_encounter_multi_stage
 from rcm_agent.crews.router_eval import _default_examples_dir, _default_golden_path, load_encounters_from_dir

--- a/src/rcm_agent/crews/e2e_eval.py
+++ b/src/rcm_agent/crews/e2e_eval.py
@@ -1,7 +1,8 @@
 """End-to-end evaluation: run full pipeline on synthetic encounters and measure outcomes.
 
-Runs process_encounter_multi_stage for each encounter, collects outcomes, and computes
-metrics: pipeline success rate, router alignment, prior auth coverage, coding/claim readiness.
+Runs process_encounter_multi_stage (or process_encounter for single-stage) for each encounter,
+collects outcomes, and computes metrics: pipeline success rate, router alignment, prior auth
+coverage, coding/claim readiness.
 Uses OpenRouter (OPENAI_API_KEY, OPENAI_API_BASE, OPENAI_MODEL_NAME) from .env for LLM calls.
 """
 
@@ -9,11 +10,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 
-from rcm_agent.crews.main_crew import process_encounter_multi_stage
+from rcm_agent.crews.main_crew import process_encounter, process_encounter_multi_stage
 from rcm_agent.crews.router_eval import _default_examples_dir, _default_golden_path, load_encounters_from_dir
 from rcm_agent.models import Encounter, EncounterOutput, EncounterStatus, RcmStage
 
@@ -96,6 +98,7 @@ class E2ESummary:
     needs_prior_auth_aligned_count: int = 0
     golden_needs_prior_auth_count: int = 0
     records: list[E2ERecord] = field(default_factory=list)
+    pipeline_mode: str = "multi"
 
     @property
     def pipeline_success_rate(self) -> float:
@@ -131,8 +134,10 @@ class E2ESummary:
             else 0.0
         )
 
+    pipeline_mode: str = "multi"
+
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "total": self.total,
             "pipeline_successes": self.pipeline_successes,
             "pipeline_success_rate": round(self.pipeline_success_rate, 3),
@@ -154,6 +159,8 @@ class E2ESummary:
             "needs_prior_auth_alignment_rate": round(self.needs_prior_auth_alignment_rate, 3),
             "records": [r.to_dict() for r in self.records],
         }
+        d["pipeline_mode"] = self.pipeline_mode
+        return d
 
 
 def _load_golden(golden_path: Path | None) -> dict[str, dict[str, Any]]:
@@ -214,6 +221,7 @@ def run_e2e_evaluation(
     golden_path: str | Path | None = None,
     output_path: str | Path | None = None,
     output_dir: str | Path | None = None,
+    pipeline_mode: str = "multi",
 ) -> E2ESummary:
     """
     Run e2e evaluation: full pipeline on each encounter, collect outcomes, compute metrics.
@@ -224,12 +232,18 @@ def run_e2e_evaluation(
         golden_path: Path to golden.json with expected stages/outcomes.
         output_path: Path to write JSON report.
         output_dir: If set, write report to output_dir/e2e_eval.json.
+        pipeline_mode: "single" | "multi" | "both". single=process_encounter (one stage);
+            multi=process_encounter_multi_stage (default); both=runs both, writes separate reports.
 
     Returns:
         E2ESummary with per-encounter records and aggregate metrics.
     """
     # Ensure config is loaded (load_dotenv via settings)
     from rcm_agent.config import settings  # noqa: F401
+
+    # Enable AUTH_DENIED for ENC-008 when running full eval (AuthDenyPayer)
+    if os.environ.get("RCM_PRIOR_AUTH_MOCK_DENY_PAYER", "").strip() == "":
+        os.environ.setdefault("RCM_PRIOR_AUTH_MOCK_DENY_PAYER", "AuthDenyPayer")
 
     if encounters is None:
         if examples_dir is None:
@@ -244,12 +258,63 @@ def run_e2e_evaluation(
 
     golden = _load_golden(Path(golden_path) if golden_path else _default_golden_path())
 
+    mode = (pipeline_mode or "multi").strip().lower()
+    if mode not in ("single", "multi", "both"):
+        mode = "multi"
+
+    def _run_single(enc: Encounter) -> list[EncounterOutput]:
+        out = process_encounter(enc)
+        return [out]
+
+    def _run_multi(enc: Encounter) -> list[EncounterOutput]:
+        return process_encounter_multi_stage(enc)
+
+    run_pipeline = _run_single if mode == "single" else _run_multi
+
+    if mode == "both":
+        summaries: list[tuple[str, E2ESummary]] = [
+            ("single", _run_e2e_pass(encounters, golden, _run_single, "single")),
+            ("multi", _run_e2e_pass(encounters, golden, _run_multi, "multi")),
+        ]
+        base = Path(output_dir) if output_dir else (Path(output_path).parent if output_path else Path("reports"))
+        base.mkdir(parents=True, exist_ok=True)
+        for name, s in summaries:
+            p = base / f"e2e_eval_{name}.json"
+            with open(p, "w", encoding="utf-8") as f:
+                json.dump(s.to_dict(), f, indent=2)
+            _write_markdown_summary(s, p.with_suffix(".md"))
+            logger.info("E2E eval %s report written to %s", name, p)
+        return summaries[-1][1]
+
+    summary = _run_e2e_pass(encounters, golden, run_pipeline, mode)
+    summary.pipeline_mode = mode
+
+    out = output_path or (Path(output_dir) / "e2e_eval.json" if output_dir else None)
+    if out:
+        out = Path(out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with open(out, "w", encoding="utf-8") as f:
+            json.dump(summary.to_dict(), f, indent=2)
+        logger.info("E2E eval report written to %s", out)
+        _write_markdown_summary(summary, out.with_suffix(".md"))
+
+    return summary
+
+
+def _run_e2e_pass(
+    encounters: list[Encounter],
+    golden: dict[str, dict[str, Any]],
+    run_pipeline: Callable[[Encounter], list[EncounterOutput]],
+    pipeline_mode: str,
+) -> E2ESummary:
+    """Run one pass of e2e evaluation with the given pipeline function."""
     summary = E2ESummary()
     summary.total = len(encounters)
+    summary.pipeline_mode = pipeline_mode
 
     for encounter in encounters:
         try:
-            outputs = process_encounter_multi_stage(encounter)
+            outputs = run_pipeline(encounter)
         except Exception as e:
             logger.exception("Pipeline failed for %s", encounter.encounter_id)
             summary.records.append(
@@ -284,15 +349,25 @@ def run_e2e_evaluation(
             "CLAIM_ACCEPTED",
         )
 
-        # Pipeline success: completed without fatal error and without inappropriate escalation
-        is_success = (
-            not escalated
-            and last is not None
-            and last.status not in _FAILURE_STATUSES
-            and (last.status in _CLEAN_STATUSES or last.stage == RcmStage.DENIAL_APPEAL)
-        )
-
         g = golden.get(encounter.encounter_id) or {}
+        expected_final = g.get("expected_final_status")
+        expected_escalation = g.get("expected_escalation", False)
+
+        # Pipeline success: when golden expects a specific outcome, success = match.
+        # When golden expects escalation (e.g. ENC-003), success = correctly escalated.
+        # When golden expects failure status (NOT_ELIGIBLE, AUTH_DENIED, CLAIM_DENIED), success = correctly produced it.
+        # Otherwise: completed without fatal error and without inappropriate escalation.
+        if expected_escalation:
+            is_success = escalated and last is not None and final_status == (expected_final or "NEEDS_REVIEW")
+        elif expected_final and expected_final in (s.value for s in _FAILURE_STATUSES):
+            is_success = not escalated and last is not None and final_status == expected_final
+        else:
+            is_success = (
+                not escalated
+                and last is not None
+                and last.status not in _FAILURE_STATUSES
+                and (last.status in _CLEAN_STATUSES or last.stage == RcmStage.DENIAL_APPEAL)
+            )
         router_aligned = _compute_router_alignment(stages_run, g)
         final_status_aligned: bool | None = None
         if "expected_final_status" in g and g["expected_final_status"] is not None:
@@ -353,17 +428,6 @@ def run_e2e_evaluation(
             summary.golden_needs_prior_auth_count += 1
             if needs_prior_auth_aligned:
                 summary.needs_prior_auth_aligned_count += 1
-
-    out = output_path or (Path(output_dir) / "e2e_eval.json" if output_dir else None)
-    if out:
-        out = Path(out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        with open(out, "w", encoding="utf-8") as f:
-            json.dump(summary.to_dict(), f, indent=2)
-        logger.info("E2E eval report written to %s", out)
-        # Write markdown summary alongside JSON
-        md_path = out.with_suffix(".md")
-        _write_markdown_summary(summary, md_path)
 
     return summary
 

--- a/src/rcm_agent/integrations/eligibility_mock.py
+++ b/src/rcm_agent/integrations/eligibility_mock.py
@@ -47,6 +47,14 @@ _MOCK_ELIGIBILITY: dict[tuple[str, str], dict[str, Any]] = {
         "in_network": True,
         "member_status": "terminated",
     },
+    ("AuthDenyPayer", "AUTH-DENY-001"): {
+        "eligible": True,
+        "plan_name": "AuthDeny Test Plan",
+        "effective_date": "2025-01-01",
+        "termination_date": None,
+        "in_network": True,
+        "member_status": "active",
+    },
 }
 
 _DEFAULT_ELIGIBILITY: dict[str, Any] = {
@@ -74,6 +82,9 @@ _MOCK_BENEFITS: dict[tuple[str, str], dict[str, dict[str, Any]]] = {
     },
     ("Anthem", "ANT777888999"): {
         "99285": {"covered": False, "copay": None, "coinsurance_pct": None, "deductible_remaining": None},
+    },
+    ("AuthDenyPayer", "AUTH-DENY-001"): {
+        "73721": {"covered": True, "copay": 0, "coinsurance_pct": 20, "deductible_remaining": 200},
     },
 }
 

--- a/src/rcm_agent/integrations/prior_auth_mock.py
+++ b/src/rcm_agent/integrations/prior_auth_mock.py
@@ -32,15 +32,16 @@ class PriorAuthMock:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         payer = (auth_packet.get("payer") or "").strip()
         decision = "denied" if _get_deny_payer() and payer == _get_deny_payer() else None
+        status = "denied" if decision == "denied" else "submitted"
         self._store[auth_id] = {
             "auth_packet": auth_packet,
-            "status": "denied" if decision == "denied" else "submitted",
+            "status": status,
             "decision": decision,
             "submitted_at": now,
         }
         return {
             "auth_id": auth_id,
-            "status": "submitted",
+            "status": status,
             "submitted_at": now,
             "message": "Prior auth request submitted successfully (mock).",
         }

--- a/src/rcm_agent/integrations/prior_auth_mock.py
+++ b/src/rcm_agent/integrations/prior_auth_mock.py
@@ -1,11 +1,20 @@
 """Mock implementation of PriorAuthBackend with in-memory auth store.
 
 Used as the default backend; submit stores the packet and poll returns approved (POC).
+
+For eval: set RCM_PRIOR_AUTH_MOCK_DENY_PAYER to a payer name to simulate AUTH_DENIED
+(e.g. RCM_PRIOR_AUTH_MOCK_DENY_PAYER=AuthDenyPayer for encounter ENC-008).
 """
 
+import os
 import uuid
 from datetime import datetime, timezone
 from typing import Any
+
+
+def _get_deny_payer() -> str:
+    """Read at runtime so eval can set env before pipeline runs."""
+    return os.environ.get("RCM_PRIOR_AUTH_MOCK_DENY_PAYER", "").strip()
 
 
 class PriorAuthMock:
@@ -21,10 +30,12 @@ class PriorAuthMock:
     def submit_auth_request(self, auth_packet: dict[str, Any]) -> dict[str, Any]:
         auth_id = f"AUTH-{uuid.uuid4().hex[:8].upper()}"
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payer = (auth_packet.get("payer") or "").strip()
+        decision = "denied" if _get_deny_payer() and payer == _get_deny_payer() else None
         self._store[auth_id] = {
             "auth_packet": auth_packet,
-            "status": "submitted",
-            "decision": None,
+            "status": "denied" if decision == "denied" else "submitted",
+            "decision": decision,
             "submitted_at": now,
         }
         return {
@@ -38,6 +49,13 @@ class PriorAuthMock:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         if auth_id in self._store:
             record = self._store[auth_id]
+            if record.get("decision") == "denied":
+                return {
+                    "auth_id": auth_id,
+                    "status": "denied",
+                    "decision": "denied",
+                    "decision_date": now,
+                }
             record["status"] = "approved"
             record["decision"] = "approved"
             record["decision_date"] = now

--- a/src/rcm_agent/main.py
+++ b/src/rcm_agent/main.py
@@ -273,10 +273,18 @@ def eval_router(examples_dir: str | None, output: str | None) -> None:
     type=click.Path(path_type=str),
     help="Path to write JSON evaluation report.",
 )
+@click.option(
+    "--pipeline",
+    "pipeline_mode",
+    default="multi",
+    type=click.Choice(["single", "multi", "both"]),
+    help="Pipeline mode: single (one stage), multi (default), or both (writes e2e_eval_single.json and e2e_eval_multi.json).",
+)
 def eval_e2e(
     examples_dir: str | None,
     golden: str | None,
     output: str | None,
+    pipeline_mode: str,
 ) -> None:
     """Run full pipeline e2e evaluation on synthetic encounters.
 
@@ -288,6 +296,7 @@ def eval_e2e(
         examples_dir=examples_dir,
         golden_path=golden,
         output_path=output,
+        pipeline_mode=pipeline_mode,
     )
     click.echo(f"Encounters evaluated: {summary.total}")
     click.echo(f"Pipeline success rate: {summary.pipeline_success_rate:.1%}")
@@ -324,7 +333,19 @@ def eval_e2e(
     type=click.Path(file_okay=False, dir_okay=True, path_type=str),
     help="Directory to write evaluation reports (default: reports).",
 )
-def eval_all(examples_dir: str | None, golden: str | None, output_dir: str | None) -> None:
+@click.option(
+    "--pipeline",
+    "pipeline_mode",
+    default="multi",
+    type=click.Choice(["single", "multi", "both"]),
+    help="E2E pipeline mode: single, multi (default), or both.",
+)
+def eval_all(
+    examples_dir: str | None,
+    golden: str | None,
+    output_dir: str | None,
+    pipeline_mode: str,
+) -> None:
     """Run full eval suite: router eval + e2e eval. Writes reports to output dir.
 
     Requires OPENAI_API_KEY in .env for LLM-backed evals.
@@ -349,6 +370,7 @@ def eval_all(examples_dir: str | None, golden: str | None, output_dir: str | Non
         examples_dir=examples_dir,
         golden_path=golden,
         output_dir=out,
+        pipeline_mode=pipeline_mode,
     )
     click.echo(f"  E2E: {e2e_summary.pipeline_success_rate:.1%} success rate")
 

--- a/src/rcm_agent/main.py
+++ b/src/rcm_agent/main.py
@@ -292,25 +292,33 @@ def eval_e2e(
     """
     from rcm_agent.crews.e2e_eval import run_e2e_evaluation
 
-    summary = run_e2e_evaluation(
+    result = run_e2e_evaluation(
         examples_dir=examples_dir,
         golden_path=golden,
         output_path=output,
         pipeline_mode=pipeline_mode,
     )
-    click.echo(f"Encounters evaluated: {summary.total}")
-    click.echo(f"Pipeline success rate: {summary.pipeline_success_rate:.1%}")
-    click.echo(f"Escalations: {summary.escalations}")
-    click.echo(f"Prior auth coverage: {summary.prior_auth_produced_count}/{summary.prior_auth_needed_count}")
-    click.echo(f"Claim readiness: {summary.reached_claims_count}/{summary.total}")
-    click.echo(f"Router alignment (vs golden): {summary.router_aligned_count}/{summary.golden_compared_count}")
-    if summary.records:
-        click.echo("\nPer-encounter details:")
-        for r in summary.records:
-            status = "OK" if r.success else "ERROR"
-            click.echo(f"  {r.encounter_id}: [{status}] stages={r.stages_run} -> {r.final_status}")
-            if r.error:
-                click.echo(f"    {r.error}")
+    if isinstance(result, tuple):
+        single_summary, multi_summary = result
+        click.echo(f"Encounters evaluated: {single_summary.total}")
+        click.echo(f"Pipeline success rate (single): {single_summary.pipeline_success_rate:.1%}")
+        click.echo(f"Pipeline success rate (multi): {multi_summary.pipeline_success_rate:.1%}")
+        click.echo("Reports: e2e_eval_single.json, e2e_eval_multi.json")
+    else:
+        summary = result
+        click.echo(f"Encounters evaluated: {summary.total}")
+        click.echo(f"Pipeline success rate: {summary.pipeline_success_rate:.1%}")
+        click.echo(f"Escalations: {summary.escalations}")
+        click.echo(f"Prior auth coverage: {summary.prior_auth_produced_count}/{summary.prior_auth_needed_count}")
+        click.echo(f"Claim readiness: {summary.reached_claims_count}/{summary.total}")
+        click.echo(f"Router alignment (vs golden): {summary.router_aligned_count}/{summary.golden_compared_count}")
+        if summary.records:
+            click.echo("\nPer-encounter details:")
+            for r in summary.records:
+                status = "OK" if r.success else "ERROR"
+                click.echo(f"  {r.encounter_id}: [{status}] stages={r.stages_run} -> {r.final_status}")
+                if r.error:
+                    click.echo(f"    {r.error}")
 
 
 @main.command("eval-all")
@@ -366,13 +374,18 @@ def eval_all(
     click.echo(f"  Router: {router_summary.agreement_rate:.1%} agreement")
 
     click.echo("Running e2e evaluation...")
-    e2e_summary = run_e2e_evaluation(
+    e2e_result = run_e2e_evaluation(
         examples_dir=examples_dir,
         golden_path=golden,
         output_dir=out,
         pipeline_mode=pipeline_mode,
     )
-    click.echo(f"  E2E: {e2e_summary.pipeline_success_rate:.1%} success rate")
+    if isinstance(e2e_result, tuple):
+        single_summary, multi_summary = e2e_result
+        click.echo(f"  E2E (single): {single_summary.pipeline_success_rate:.1%} success rate")
+        click.echo(f"  E2E (multi): {multi_summary.pipeline_success_rate:.1%} success rate")
+    else:
+        click.echo(f"  E2E: {e2e_result.pipeline_success_rate:.1%} success rate")
 
     click.echo(f"\nReports written to {out}/")
     click.echo("  - router_eval.json")

--- a/src/rcm_agent/main.py
+++ b/src/rcm_agent/main.py
@@ -376,7 +376,11 @@ def eval_all(
 
     click.echo(f"\nReports written to {out}/")
     click.echo(f"  - router_eval.json")
-    click.echo(f"  - e2e_eval.json")
+    if pipeline_mode == "both":
+        click.echo(f"  - e2e_eval_single.json")
+        click.echo(f"  - e2e_eval_multi.json")
+    else:
+        click.echo(f"  - e2e_eval.json")
 
 
 @main.command("process-multi")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,6 +195,12 @@ def test_persistence_cli_pipeline(
         assert row["encounter_id"] == "ENC-001"
         assert row["stage"] in [s.value for s in RcmStage], f"Invalid stage: {row['stage']}"
         assert row["status"] in [s.value for s in EncounterStatus], f"Invalid status: {row['status']}"
+        # ENC-001 routine visit should reach a clean claim outcome
+        assert row["status"] in (
+            EncounterStatus.CLAIM_ACCEPTED.value,
+            EncounterStatus.CLAIM_SUBMITTED.value,
+            EncounterStatus.CODED.value,
+        ), f"ENC-001 should complete with claim outcome, got {row['status']}"
 
         audit = repo.get_audit_log("ENC-001")
         assert len(audit) >= 2, "Audit log should have process_started and workflow_complete"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,9 +174,7 @@ def test_denial_stats_command(cli_runner: CliRunner, examples_dir: Path, tmp_db_
 
 
 @pytest.mark.e2e
-def test_persistence_cli_pipeline(
-    cli_runner: CliRunner, examples_dir: Path, tmp_db_path: str
-) -> None:
+def test_persistence_cli_pipeline(cli_runner: CliRunner, examples_dir: Path, tmp_db_path: str) -> None:
     """Run pipeline via CLI (process command), read back from repository, assert stored state matches.
 
     Verifies that rcm-agent process persists encounter status, stage, and audit trail correctly.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,3 +171,32 @@ def test_denial_stats_command(cli_runner: CliRunner, examples_dir: Path, tmp_db_
     assert result2.exit_code == 0
     assert "1" in result2.output  # at least one event
     assert "By reason code:" in result2.output or "By denial type:" in result2.output
+
+
+@pytest.mark.e2e
+def test_persistence_cli_pipeline(
+    cli_runner: CliRunner, examples_dir: Path, tmp_db_path: str
+) -> None:
+    """Run pipeline via CLI (process command), read back from repository, assert stored state matches.
+
+    Verifies that rcm-agent process persists encounter status, stage, and audit trail correctly.
+    Uses temp DB for deterministic, fast execution.
+    """
+    from rcm_agent.db import EncounterRepository
+    from rcm_agent.models import EncounterStatus, RcmStage
+
+    encounter_file = examples_dir / "encounter_001_routine_visit.json"
+    result = cli_runner.invoke(main, ["--db-path", tmp_db_path, "process", str(encounter_file)])
+    assert result.exit_code == 0, result.output
+
+    with EncounterRepository(tmp_db_path) as repo:
+        row = repo.get_encounter("ENC-001")
+        assert row is not None, "Encounter should be persisted"
+        assert row["encounter_id"] == "ENC-001"
+        assert row["stage"] in [s.value for s in RcmStage], f"Invalid stage: {row['stage']}"
+        assert row["status"] in [s.value for s in EncounterStatus], f"Invalid status: {row['status']}"
+
+        audit = repo.get_audit_log("ENC-001")
+        assert len(audit) >= 2, "Audit log should have process_started and workflow_complete"
+        actions = {e["action"] for e in audit}
+        assert "process_started" in actions or "workflow_complete" in actions

--- a/tests/test_e2e_eval.py
+++ b/tests/test_e2e_eval.py
@@ -234,3 +234,210 @@ def test_run_e2e_evaluation_pipeline_error(
     assert r.final_status == "ERROR"
     assert r.error == "LLM timeout"
     assert r.success is False
+
+
+@patch("rcm_agent.crews.e2e_eval.process_encounter_multi_stage")
+def test_run_e2e_evaluation_failure_status_success(
+    mock_pipeline: object,
+    encounter_005: Encounter,
+    tmp_path: Path,
+) -> None:
+    """When golden expects NOT_ELIGIBLE, mock returning NOT_ELIGIBLE is success."""
+    mock_pipeline.return_value = [
+        EncounterOutput(
+            encounter_id="ENC-005",
+            stage=RcmStage.ELIGIBILITY_VERIFICATION,
+            status=EncounterStatus.NOT_ELIGIBLE,
+            actions_taken=[],
+            artifacts=[],
+            message="Not eligible",
+            raw_result={},
+        ),
+    ]
+    golden_path = tmp_path / "golden.json"
+    golden_path.write_text(
+        '{"ENC-005": {"expected_stages": ["ELIGIBILITY_VERIFICATION"], "expected_final_status": "NOT_ELIGIBLE"}}'
+    )
+    summary = run_e2e_evaluation(
+        encounters=[encounter_005],
+        golden_path=golden_path,
+        pipeline_mode="multi",
+    )
+    assert summary.total == 1
+    r = summary.records[0]
+    assert r.final_status == "NOT_ELIGIBLE"
+    assert r.success is True
+
+
+@patch("rcm_agent.crews.e2e_eval.process_encounter_multi_stage")
+def test_run_e2e_evaluation_escalation_success(
+    mock_pipeline: object,
+    encounter_003: Encounter,
+    tmp_path: Path,
+) -> None:
+    """When golden expects escalation, mock returning HUMAN_ESCALATION + NEEDS_REVIEW is success."""
+    mock_pipeline.return_value = [
+        EncounterOutput(
+            encounter_id="ENC-003",
+            stage=RcmStage.HUMAN_ESCALATION,
+            status=EncounterStatus.NEEDS_REVIEW,
+            actions_taken=[],
+            artifacts=[],
+            message="Escalated",
+            raw_result={},
+        ),
+    ]
+    golden_path = tmp_path / "golden.json"
+    golden_path.write_text(
+        '{"ENC-003": {"expected_stages": ["HUMAN_ESCALATION"], "expected_final_status": "NEEDS_REVIEW", "expected_escalation": true}}'
+    )
+    summary = run_e2e_evaluation(
+        encounters=[encounter_003],
+        golden_path=golden_path,
+        pipeline_mode="multi",
+    )
+    assert summary.total == 1
+    r = summary.records[0]
+    assert r.final_status == "NEEDS_REVIEW"
+    assert r.escalated is True
+    assert r.success is True
+
+
+@patch("rcm_agent.crews.e2e_eval.process_encounter")
+def test_run_e2e_evaluation_pipeline_mode_single(
+    mock_single: object,
+    encounter_001: Encounter,
+    tmp_path: Path,
+) -> None:
+    """Pipeline mode single uses process_encounter; report has pipeline_mode single."""
+    mock_single.return_value = EncounterOutput(
+        encounter_id="ENC-001",
+        stage=RcmStage.CODING_CHARGE_CAPTURE,
+        status=EncounterStatus.CODED,
+        actions_taken=[],
+        artifacts=[],
+        message="Coded",
+        raw_result={},
+    )
+    golden_path = tmp_path / "golden.json"
+    golden_path.write_text("{}")
+    output_path = tmp_path / "e2e_single.json"
+    summary = run_e2e_evaluation(
+        encounters=[encounter_001],
+        golden_path=golden_path,
+        output_path=output_path,
+        pipeline_mode="single",
+    )
+    assert isinstance(summary, E2ESummary)
+    assert summary.pipeline_mode == "single"
+    assert summary.total == 1
+    assert output_path.exists()
+    data = json.loads(output_path.read_text())
+    assert data["pipeline_mode"] == "single"
+
+
+@patch("rcm_agent.crews.e2e_eval.process_encounter_multi_stage")
+@patch("rcm_agent.crews.e2e_eval.process_encounter")
+def test_run_e2e_evaluation_pipeline_mode_both(
+    mock_single: object,
+    mock_multi: object,
+    encounter_001: Encounter,
+    tmp_path: Path,
+) -> None:
+    """Pipeline mode both writes e2e_eval_single.json and e2e_eval_multi.json with correct pipeline_mode."""
+    out_single = EncounterOutput(
+        encounter_id="ENC-001",
+        stage=RcmStage.CODING_CHARGE_CAPTURE,
+        status=EncounterStatus.CODED,
+        actions_taken=[],
+        artifacts=[],
+        message="Coded",
+        raw_result={},
+    )
+    mock_single.return_value = out_single
+    mock_multi.return_value = [out_single]
+    golden_path = tmp_path / "golden.json"
+    golden_path.write_text("{}")
+    result = run_e2e_evaluation(
+        encounters=[encounter_001],
+        golden_path=golden_path,
+        output_dir=tmp_path,
+        pipeline_mode="both",
+    )
+    assert isinstance(result, tuple)
+    single_summary, multi_summary = result
+    assert single_summary.pipeline_mode == "single"
+    assert multi_summary.pipeline_mode == "multi"
+    single_path = tmp_path / "e2e_eval_single.json"
+    multi_path = tmp_path / "e2e_eval_multi.json"
+    assert single_path.exists()
+    assert multi_path.exists()
+    assert json.loads(single_path.read_text())["pipeline_mode"] == "single"
+    assert json.loads(multi_path.read_text())["pipeline_mode"] == "multi"
+
+
+def test_run_e2e_evaluation_env_not_overridden(
+    encounter_001: Encounter,
+    tmp_path: Path,
+) -> None:
+    """When RCM_PRIOR_AUTH_MOCK_DENY_PAYER is already set, eval does not overwrite it."""
+    import os
+
+    with patch("rcm_agent.crews.e2e_eval.process_encounter_multi_stage") as mock_pipeline:
+        mock_pipeline.return_value = [
+            EncounterOutput(
+                encounter_id="ENC-001",
+                stage=RcmStage.CODING_CHARGE_CAPTURE,
+                status=EncounterStatus.CODED,
+                actions_taken=[],
+                artifacts=[],
+                message="Coded",
+                raw_result={},
+            ),
+        ]
+        key = "RCM_PRIOR_AUTH_MOCK_DENY_PAYER"
+        os.environ[key] = "OtherPayer"
+        try:
+            run_e2e_evaluation(
+                encounters=[encounter_001],
+                golden_path=tmp_path / "golden.json",
+                output_path=tmp_path / "out.json",
+            )
+            assert os.environ.get(key) == "OtherPayer"
+        finally:
+            os.environ.pop(key, None)
+
+
+def test_run_e2e_evaluation_env_restored_when_set(
+    encounter_001: Encounter,
+    tmp_path: Path,
+) -> None:
+    """When key was not set, eval sets it for the run then restores (removes) afterward."""
+    import os
+
+    key = "RCM_PRIOR_AUTH_MOCK_DENY_PAYER"
+    saved = os.environ.pop(key, None)
+    try:
+        with patch("rcm_agent.crews.e2e_eval.process_encounter_multi_stage") as mock_pipeline:
+            mock_pipeline.return_value = [
+                EncounterOutput(
+                    encounter_id="ENC-001",
+                    stage=RcmStage.CODING_CHARGE_CAPTURE,
+                    status=EncounterStatus.CODED,
+                    actions_taken=[],
+                    artifacts=[],
+                    message="Coded",
+                    raw_result={},
+                ),
+            ]
+            run_e2e_evaluation(
+                encounters=[encounter_001],
+                golden_path=tmp_path / "golden.json",
+                output_path=tmp_path / "out.json",
+            )
+        assert key not in os.environ or os.environ.get(key, "").strip() == ""
+    finally:
+        if saved is not None:
+            os.environ[key] = saved
+        else:
+            os.environ.pop(key, None)


### PR DESCRIPTION
This pull request significantly expands and improves the end-to-end (E2E) evaluation framework for the RCM agentic system. It adds new encounter scenarios to the golden evaluation set, introduces support for both single-stage and multi-stage pipeline evaluation modes, and enhances metrics and alignment checks (including prior auth outcome alignment). The documentation is updated to reflect these improvements and to clarify coverage, failure scenarios, and optional backend configurations.

**Expanded E2E evaluation scenarios and metrics:**

* Added new encounters (ENC-003 through ENC-008) to `data/eval/golden.json` with expected stages, final statuses, escalation, and prior auth outcomes, covering denial, eligibility, escalation, duplicate claim, and prior auth denial scenarios.
* Added example files for duplicate claim (`encounter_007_duplicate_claim.json`) and prior auth denied (`encounter_008_auth_denied.json`). [[1]](diffhunk://#diff-3100a3756c54b77464905d234e982c58755f2ca89e74da0ba110d38a43e4e0b6R1-R11) [[2]](diffhunk://#diff-6a0e566fe5a395d52e4be696e46f173b3ad101f8404cbbf69c05c4170a1b688bR1-R16)

**Pipeline mode and output enhancements:**

* Introduced pipeline mode selection (`single`, `multi`, `both`) to E2E evaluation, allowing comparison between single-stage and multi-stage pipelines and writing separate reports for each mode. [[1]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eL3-R25) [[2]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56R50-R62) [[3]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56L75-R86)
* Updated E2E summary and record structures to track pipeline mode and new metrics, including prior auth outcome alignment. [[1]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR62) [[2]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR80) [[3]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR104-R107) [[4]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR143-R152) [[5]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR172-R178)
* Refactored `run_e2e_evaluation` to support pipeline mode, prior auth denial payer override, and robust environment handling. [[1]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eL217-R241) [[2]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR251-R271) [[3]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR285-R349) [[4]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR365)

**Documentation updates and coverage clarification:**

* Updated `docs/EVAL.md` to document pipeline modes, expanded golden scenarios, new metrics, and optional RAG/HTTP backend usage. Clarified coverage, limitations, and interpretation of metrics, including escalation and failure scenario handling. [[1]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56L95-R103) [[2]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56R115-R157)

**Summary of most important changes:**

Expanded evaluation scenarios:
- Added new golden entries for denial, escalation, eligibility mismatch, duplicate claim, and prior auth denial, ensuring all synthetic encounters are covered in regression testing.
- Added example files for duplicate claim and prior auth denied encounters. [[1]](diffhunk://#diff-3100a3756c54b77464905d234e982c58755f2ca89e74da0ba110d38a43e4e0b6R1-R11) [[2]](diffhunk://#diff-6a0e566fe5a395d52e4be696e46f173b3ad101f8404cbbf69c05c4170a1b688bR1-R16)

Pipeline mode and metrics:
- Introduced pipeline mode selection (`single`, `multi`, `both`) and updated output/reporting to support comparison and expanded metrics. [[1]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eL3-R25) [[2]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56R50-R62) [[3]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56L75-R86)
- Enhanced E2E summary and record structures to track new metrics, including prior auth outcome alignment and pipeline mode. [[1]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR62) [[2]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR80) [[3]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR104-R107) [[4]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR143-R152) [[5]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR172-R178)
- Refactored evaluation logic to handle pipeline mode, prior auth denial payer override, and robust environment state management. [[1]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eL217-R241) [[2]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR251-R271) [[3]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR285-R349) [[4]](diffhunk://#diff-964186abacb6fedaf13d42f0253d242b3968c192c7e6f7083356f1d65d002d6eR365)

Documentation and coverage:
- Updated `docs/EVAL.md` to reflect expanded scenarios, pipeline mode options, new metrics, and clarified coverage and limitations. [[1]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56L95-R103) [[2]](diffhunk://#diff-2afa27d49f61080ba0546251243d35eae9db051364ec99f05ae0f71d26772f56R115-R157)

These changes make the E2E evaluation more comprehensive, robust, and configurable, supporting regression testing across a wider range of scenarios and pipeline modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the evaluation harness and mock backends (env-driven auth denial) and changes how E2E success is computed, which could affect CI signal and regression comparisons; production pipeline logic is largely untouched.
> 
> **Overview**
> Expands E2E evaluation coverage by adding golden expectations for all encounters `ENC-001`–`ENC-008`, including explicit escalation (`ENC-003`), eligibility failure (`ENC-005`), duplicate-claim denial (`ENC-007`), and prior-auth denial (`ENC-008`), plus new example encounter JSONs for the latter two scenarios.
> 
> Updates `run_e2e_evaluation` to support `single`, `multi`, or `both` pipeline modes (writing separate reports in `both`), and extends E2E reporting to include `pipeline_mode` plus auth-outcome alignment; success criteria are tightened to treat *expected* escalations and expected failure statuses as successful when they match golden.
> 
> Adds a configurable mock prior-auth denial path keyed off `RCM_PRIOR_AUTH_MOCK_DENY_PAYER` (with eval-time env override/restore) and extends eligibility mock data for the new payer, wires the new `--pipeline` option into `eval-e2e`/`eval-all`, and adds unit/e2e tests (including a persistence-through-CLI e2e test) and documentation updates in `docs/EVAL.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3739321d2dd823813364ac8e604f7fb8b3e59a5f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->